### PR TITLE
Threads and Questions UI - almost done 🍟

### DIFF
--- a/backend/src/controllers/queries/QueryQuestions.js
+++ b/backend/src/controllers/queries/QueryQuestions.js
@@ -7,6 +7,7 @@ const QueryQuestions = async (req, res) => {
             id
         },
         select: {
+            name: true,
             Question: {
                 select: {
                     id: true,
@@ -17,7 +18,7 @@ const QueryQuestions = async (req, res) => {
     })
     return res.json({
         success: true,
-        questions: find.Question
+        questions: find
     })
 }
 

--- a/frontend/components/description.jsx
+++ b/frontend/components/description.jsx
@@ -1,7 +1,7 @@
 const Description = ({ question }) => {
     return (
         <>
-            <article class="media card p-4 mb-6">
+            <article class="media card p-4 mb-5">
                 <figure class="media-left">
                     <p class="image is-64x64">
                         <img src="https://bit.ly/38xqVO3" />

--- a/frontend/components/index.js
+++ b/frontend/components/index.js
@@ -1,3 +1,5 @@
 export { default as Navbar } from './navbar'
 export { default as Description } from './description'
 export { default as CommentList } from './commentList'
+export { default as ThreadBox } from './threadBox'
+export { default as QuestionsBox } from './questionsBox'

--- a/frontend/components/questionsBox.jsx
+++ b/frontend/components/questionsBox.jsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+import { GiCookie } from 'react-icons/gi'
+
+const QuestionsBox = ({ question, threadName }) => {
+    return (
+        <Link href={'/question/' + question.id}>
+            <div className="box">
+                <article className="media  is-align-items-center">
+                    <div className="media-left mt-1" style={{ fontSize: 24, color: '#f03a5f' }}>
+                        <GiCookie />
+                    </div>
+                    <div className="media-content">
+                        <div className="content">
+                            <p className="is-size-5 has-text-weight-medium">{question.title}</p>
+                        </div>
+                    </div>
+                    <div className="media-right">
+                        <span class="tag is-info is-light p-4">{threadName}</span>
+                    </div>
+                </article>
+            </div>
+        </Link>
+
+    )
+}
+
+export default QuestionsBox

--- a/frontend/components/threadBox.jsx
+++ b/frontend/components/threadBox.jsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { GiBigEgg } from 'react-icons/gi'
+
+const ThreadBox = ({ thread, count }) => {
+    return (
+        <Link href={"/questions/" + thread.id}>
+            <div className="box">
+                <article className="media  is-align-items-center">
+                    <div className="media-left mt-1" style={{ fontSize: 24, color: '#f03a5f' }}>
+                        <GiBigEgg />
+                    </div>
+                    <div className="media-content">
+                        <div className="content">
+                            <p className="is-size-5 has-text-weight-medium">{thread.name}</p>
+                        </div>
+                    </div>
+                    <div className="media-right">
+                        {count === 1 ? (
+                            <span class="tag is-info is-light p-4">{count} question</span>
+                        ) : (
+                                <span class="tag is-info is-light p-4">{count} questions</span>
+                            )}
+                    </div>
+                </article>
+            </div>
+        </Link>
+
+    )
+}
+
+export default ThreadBox

--- a/frontend/pages/questions/[id].jsx
+++ b/frontend/pages/questions/[id].jsx
@@ -1,18 +1,20 @@
 import Head from 'next/head'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { Navbar } from '../../components'
+import { Navbar, QuestionsBox } from '../../components'
 
 const Questions = () => {
     const data = {
         "success": true,
-        "questions": [
+        "questions": {
+          "name": "Anime",
+          "Question": [
             {
-                "id": "c11d04ef-51e0-4a46-b21b-4829db6fd5e3",
-                "title": "Bleach: Sennen Kessen-hen (S2)"
+              "id": "c11d04ef-51e0-4a46-b21b-4829db6fd5e3",
+              "title": "Bleach: Sennen Kessen-hen (S2)"
             }
-        ]
-    }
+          ]
+        }
+      }
     const router = useRouter()
     const { id } = router.query
     return (
@@ -35,15 +37,8 @@ const Questions = () => {
                     <div className="container">
                         <div className="columns is-justify-content-center">
                             <div className="column is-8">
-                                {data.questions.map(question => {
-                                    return (
-                                        <Link href={'/question/' + question.id}>
-                                            <div className="card p-4">
-                                                <strong>Selected Thread ID:</strong> {id} <br /><br />
-                                                <strong>Question Title:</strong> {question.title}
-                                            </div>
-                                        </Link>
-                                    )
+                                {data.questions.Question.map(question => {
+                                    return <QuestionsBox question={question} threadName={data.questions.name} />
                                 })}
                             </div>
                         </div>

--- a/frontend/pages/threads.jsx
+++ b/frontend/pages/threads.jsx
@@ -1,6 +1,5 @@
-import Link from 'next/link'
 import Head from 'next/head'
-import { Navbar } from '../components'
+import { Navbar, ThreadBox } from '../components'
 
 const Threads = () => {
     const data = {
@@ -12,6 +11,7 @@ const Threads = () => {
             }
         ]
     }
+    const count = data.threads.length
     return (
         <>
             <Head>
@@ -33,13 +33,7 @@ const Threads = () => {
                         <div className="columns is-justify-content-center">
                             <div className="column is-8">
                                 {data.threads.map(thread => {
-                                    return (
-                                        <Link href={"/questions/" + thread.id}>
-                                            <div className="card p-4">
-                                                <strong>Thread Name:</strong> {thread.name}
-                                            </div>
-                                        </Link>
-                                    )
+                                    return <ThreadBox thread={thread} count={count} />
                                 })}
                             </div>
                         </div>


### PR DESCRIPTION
I made changes to the UI of the threads and questions page. In these I created some components to be able to pass props so that it is more dynamic and simpler to maintain their code.

In addition to this I changed a line in the query of the questions in the backend, added the name of the thread in the response object so that in the frontend I can put in the tag of the questions component the thread to which it belongs.